### PR TITLE
Update Setup-RoTerror.tp2

### DIFF
--- a/RoTerror/Setup-RoTerror.tp2
+++ b/RoTerror/Setup-RoTerror.tp2
@@ -1700,11 +1700,6 @@ END
 // biffing
 //////////////////////////////
 
-ACTION_IF (GAME_IS ~bg2ee eet~) BEGIN		//older mods use RoT-RULE
-	MAKE_BIFF ~RoT-RULE~ BEGIN
-		~override~ ~RoT.mrk~
-	END
-END
 
 ACTION_IF (GAME_IS ~bg2 tob bgt~) BEGIN
 	MAKE_BIFF ~RoT-RULE~ BEGIN


### PR DESCRIPTION
No BG2EE or EET mod uses this marker
Instead it falsely prevents some components from Tweaks Anthology to install
See http://baldursextendedworld.com/Vanilla_Forums/discussion/comment/3866/#Comment_3866